### PR TITLE
Platform: Ability to replay events on timemachine [#86203214]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    routemaster-client (1.1.0)
+    routemaster-client (1.2.0)
       faraday (>= 0.9.0)
       net-http-persistent
       wisper (>= 1.4.0)

--- a/app/services/replay.rb
+++ b/app/services/replay.rb
@@ -1,7 +1,8 @@
 class Replay
 
   def initialize(scope)
-    @scope = scope
+    @scope   = scope
+    @clients = {}
   end
 
   def replay
@@ -11,22 +12,41 @@ class Replay
   private
 
   def send_event(event)
-    routemaster_event_type = case event.type.to_s
-                             when 'create' then 'created'
-                             when 'update' then 'updated'
-                             when 'delete' then 'deleted'
-                             when 'noop'   then 'noop'
-                             end
+    event_type = case event.type.to_s
+                 when 'create' then 'created'
+                 when 'update' then 'updated'
+                 when 'delete' then 'deleted'
+                 when 'noop'   then 'noop'
+                 end
 
-    client.public_send(routemaster_event_type, event.topic.pluralize, event.url, (event.t * 1000).to_f)
+    topic = event.topic.pluralize
+    uuid  = publisher(topic)
+
+    client_as_uuid(uuid).public_send(event_type, topic, event.url, (event.t * 1000).to_f)
   end
 
   def client
-    @routemaster_client ||= Routemaster::Client.new(
+    @client ||= Routemaster::Client.new(
       url:  ENV['ROUTEMASTER_URL'],
       uuid: ENV['ROUTEMASTER_CLIENT_UUID'],
       timeout: 1
     )
+  end
+
+  def client_as_uuid(uuid)
+    @clients[uuid] ||= Routemaster::Client.new(
+      url:  ENV['ROUTEMASTER_URL'],
+      uuid: uuid,
+      timeout: 1
+    )
+  end
+
+  def publisher(topic_name)
+    topics.find { |topic| topic[:name] == topic_name }[:publisher]
+  end
+
+  def topics
+    @topics ||= client.monitor_topics.map(&:attributes)
   end
 
 end

--- a/spec/services/replay_spec.rb
+++ b/spec/services/replay_spec.rb
@@ -2,24 +2,48 @@ require 'rails_helper'
 
 RSpec.describe Replay do
 
-  let(:url)    { 'http://foo.example.com/topics/1' }
-  let(:type)   { 'update'  }
-  let(:topic)  { 'topic' }
-  let(:t)      { 10.minutes.ago.to_i }
-  let(:event)  { Event.create(url: url, type: type, topic: topic, t: t) }
-  let(:client) { instance_double("Routemaster::Client") }
+  let(:url)            { 'http://foo.example.com/topics/1' }
+  let(:type)           { 'update'  }
+  let(:topic)          { 'topic' }
+  let(:t)              { 10.minutes.ago.to_i }
+  let(:event)          { Event.create(url: url, type: type, topic: topic, t: t) }
+  let(:client)         { instance_double("Routemaster::Client") }
+  let(:publisher)      { instance_double("Routemaster::Client") }
+  let(:publisher_uuid) { 'foo' }
 
   describe '#replay' do
 
     before do
-      allow(Routemaster::Client).to receive(:new).and_return(client)
+      allow(Routemaster::Client).to receive(:new)
+        .with({
+          url:  ENV['ROUTEMASTER_URL'],
+          uuid: ENV['ROUTEMASTER_CLIENT_UUID'],
+          timeout: 1
+        })
+        .and_return(client)
+
+      allow(Routemaster::Client).to receive(:new)
+        .with({
+          url:  ENV['ROUTEMASTER_URL'],
+          uuid: publisher_uuid,
+          timeout: 1
+        })
+        .and_return(publisher)
+
+      allow(client).to receive(:monitor_topics).and_return([
+        Routemaster::Topic.new({
+          "name"      => topic.pluralize,
+          "publisher" => publisher_uuid,
+          "events"    => 100
+        })
+      ])
     end
 
     context 'when doing a single replay' do
       subject { described_class.new(Event.where(id: event.id)) }
 
       it 'sends a routemaster event' do
-        expect(client).to receive(:updated).with('topics', url, t * 1000)
+        expect(publisher).to receive(:updated).with('topics', url, t * 1000)
         subject.replay
       end
     end
@@ -32,7 +56,7 @@ RSpec.describe Replay do
       subject { described_class.new(Event.all) }
 
       it 'sends a routemaster event' do
-        expect(client).to receive(:updated).with('topics', url, t * 1000).twice
+        expect(publisher).to receive(:updated).with('topics', url, t * 1000).twice
         subject.replay
       end
     end


### PR DESCRIPTION
Pivotal tracker story [#86203214](https://www.pivotaltracker.com/story/show/86203214) in project *Platform*:

> ## Why
> The prototype of routemaster-timemachine added almost all infrastructure and UI to replay specific events, however there is an issue on routemaster https://github.com/HouseTrip/routemaster/issues/41. This prevents the app to replay events because it can't send them with its own publisher, since only the original publisher can do this.
> 
> ## What
> Modify the replay functionality to set the UUID of the topic publisher so it can impersonate through routemaster as the original publisher.
> 
> ## Test
> - Events can be replayed from routemaster-timemachine
> - Test suite is green

This PR enables the timemachine to impersonate a publisher by setting the UUID on a `Routemaster::Client` instance followed by sending a previous recorded event.

Considering that replaying events is something very extraordinary and not something that is meant to be done often, I think it's not worth to cache the information from: _who is the publisher of each topic_ more than the life time of each replay request. 

- Tested on a staging environment :earth_asia:

This PR was also originated by the discussion on: https://github.com/HouseTrip/routemaster/issues/41
