### PR TITLE
Platform: Create job that deletes events older than 2 days [#88026074]

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -53,6 +53,7 @@ guard :rspec, cmd: "bin/rspec" do
   rails = dsl.rails(view_extensions: %w(erb haml slim))
   dsl.watch_spec_files_for(rails.app_files)
   dsl.watch_spec_files_for(rails.views)
+  dsl.watch_spec_files_for(rails.workers)
 
   watch(rails.controllers) do |m|
     [

--- a/app/workers/sweeper.rb
+++ b/app/workers/sweeper.rb
@@ -1,0 +1,11 @@
+class Sweeper
+
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+
+  recurrence { hourly.minute_of_hour(0, 30) }
+
+  def perform
+    Event.where('created_at < ?', 3.days.ago).delete_all
+  end
+end

--- a/spec/workers/sweeper_spec.rb
+++ b/spec/workers/sweeper_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Sweeper do
+
+  before do
+    Event.create(created_at: 10.days.ago)
+    Event.create(created_at: 8.days.ago)
+    Event.create(created_at: 6.days.ago)
+    Event.create(created_at: 1.days.ago)
+  end
+
+  it 'deletes past events' do
+    expect { described_class.new.perform }
+      .to change { Event.count }.from(4).to(1)
+  end
+end


### PR DESCRIPTION
Pivotal tracker story [#88026074](https://www.pivotaltracker.com/story/show/88026074) in project *Platform*:

> ## Why
> 
> The timemachine is not able to cope with so many events on that table if pagination is applied. It becomes very slow and prevents access to the UI.
> 
> ## What
> 
> Create a periodic job that every hour deletes events older than 3 days
> 
> ## Testing
> 
> Test on staging this works
> Test suite is green