### PR TITLE
Platform: Batch replaying the events via jobs [#88028892]

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,10 +22,10 @@ class EventsController < ApplicationController
   end
 
   def replay_events
-    @events = EventSearch.new(params[:event_search] || {})
+    ReplayWorker.perform_async(params[:event_search] || {})
 
-    Replay.new(@events.scope).replay
-    redirect_to events_path(params.slice(:event_search)), notice: 'Events replayed successfully'
+    redirect_to events_path(params.slice(:event_search)),
+      notice: 'A job was scheduled to replay the selected events'
   end
 
 end

--- a/app/services/event_search.rb
+++ b/app/services/event_search.rb
@@ -20,6 +20,7 @@ class EventSearch
   attr_reader :t, :topic, :type
 
   def initialize(options = {})
+    options    = options.symbolize_keys
     @order     = options.fetch(:order, [{ t: :desc }])
     @page      = options.fetch(:page, 1)
     @per_page  = options.fetch(:per_page, 200)

--- a/app/workers/replay_worker.rb
+++ b/app/workers/replay_worker.rb
@@ -1,0 +1,10 @@
+class ReplayWorker
+
+  include Sidekiq::Worker
+
+  def perform(options = {})
+    scope = EventSearch.new(options).scope
+    Replay.new(scope).replay
+  end
+
+end

--- a/spec/services/event_search_spec.rb
+++ b/spec/services/event_search_spec.rb
@@ -6,6 +6,20 @@ RSpec.describe EventSearch do
 
   subject { described_class.new(options) }
 
+  context 'when options has strings as keys' do
+
+    let(:options) do
+      {
+        "topic" => ['photos', 'properties']
+      }
+    end
+
+    it 'captures the right topics' do
+      expect(subject.topic).to eql(options["topic"])
+    end
+
+  end
+
   describe 'ordering' do
     let!(:event_1) { Event.create(t: 2.minutes.ago.to_f) }
     let!(:event_2) { Event.create(t: 1.minutes.ago.to_f) }

--- a/spec/workers/replay_worker_spec.rb
+++ b/spec/workers/replay_worker_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ReplayWorker do
+
+  before do
+    allow_any_instance_of(Replay).to receive(:replay)
+  end
+
+  it 'calls Replay with the expected scope' do
+    expect(Replay).to receive(:new)
+      .with(EventSearch.new.scope)
+      .and_call_original
+
+    described_class.new.perform
+  end
+
+  context 'when specific topic' do
+
+    let(:options) do
+      { topic: ["photos"] }
+    end
+
+    it 'calls replay with the filtered scope' do
+      expect(Replay).to receive(:new)
+        .with(EventSearch.new(options).scope)
+        .and_call_original
+
+      described_class.new.perform(options)
+    end
+  end
+end


### PR DESCRIPTION
Pivotal tracker story [#88028892](https://www.pivotaltracker.com/story/show/88028892) in project *Platform*:

> ## Why
> Replaying events is done in the web worker currently, Heroku doesn't like long-lived requests and will kill the request after a few seconds. 
> 
> ## What
> Schedule job(s) to process the replay of events
> 
> ## Testing
> This works as intended on staging for 10k events at least