### PR TITLE
Platform: Create an alert whenever Timemachine is not logging any events for more than X hours [#88685298]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.6.0)
-    spring (1.2.0)
+    spring (1.3.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (2.12.3)

--- a/Guardfile
+++ b/Guardfile
@@ -32,7 +32,7 @@
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, cmd: "bin/rspec" do
+guard :rspec, cmd: "bundle exec spring rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/app/controllers/monitor_controller.rb
+++ b/app/controllers/monitor_controller.rb
@@ -1,0 +1,18 @@
+class MonitorController < ApplicationController
+
+  def health
+    health = Event.where(created_at: monitor_window).count >= monitor_threshold
+    render layout: false, text: health
+  end
+
+  private
+
+  def monitor_window
+    ENV.fetch('MONITOR_EVENTS_WINDOW', 120).to_i.minutes.ago..Time.now
+  end
+
+  def monitor_threshold
+    ENV.fetch('MONITOR_EVENTS_THRESHOLD', 50).to_i
+  end
+
+end

--- a/bin/spring
+++ b/bin/spring
@@ -1,17 +1,14 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast
-# It gets overwritten when you run the `spring binstub` command
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
   require "rubygems"
   require "bundler"
 
   if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
-    ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
-    ENV["GEM_HOME"] = ""
-    Gem.paths = ENV
-
+    Gem.paths = { "GEM_PATH" => Bundler.bundle_path.to_s }
     gem "spring", match[1]
     require "spring/binstub"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'health', to: 'monitor#health'
+
   mount $drainer => '/events'
 
   root 'events#index'

--- a/spec/controllers/monitor_controller_spec.rb
+++ b/spec/controllers/monitor_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe MonitorController do
+
+  describe 'health' do
+
+    it 'requires login' do
+      get :health
+      expect(response.code).to eql('401')
+    end
+
+    context 'when authenticated' do
+      before { http_login }
+
+      it 'renders false by default' do
+        get :health
+        expect(response.body).to eql('false')
+      end
+
+      context 'when enough events to cover the threshold' do
+
+        let(:test_threshold) { 5 }
+
+        around do |example|
+          threshold = ENV['MONITOR_EVENTS_THRESHOLD']
+          ENV['MONITOR_EVENTS_THRESHOLD'] = test_threshold.to_s
+          example.run
+          ENV['MONITOR_EVENTS_THRESHOLD'] = threshold.to_s
+        end
+
+        before do
+          test_threshold.times { Event.create }
+        end
+
+        it 'renders true if events created exceed the acceptable threshold' do
+          get :health
+          expect(response.body).to eql('true')
+        end
+
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
Pivotal tracker story [#88685298](https://www.pivotaltracker.com/story/show/88685298) in project *Platform*:

> ## Why
> We would like to be alerted whenever the timeachine hasn't logged any events for X hours.
> 
> ## What
> Make sure new relic can raise an alert if X hours have passed an no event has been logged
> X should be configurable via environment var