### PR TITLE
Fix event show

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,7 +12,7 @@
     <dt class="text-uppercase"><strong><%= Event.human_attribute_name(:topic) %>:</strong></dt>
     <dd><%= @event.topic %></dd>
     <dt class="text-uppercase"><strong>Sent at:</strong></dt>
-    <dd><%= l Time.at(@event.t/1000) %></dd>
+    <dd><%= l Time.at(@event.t) %></dd>
     <dt class="text-uppercase"><strong>Received at:</strong></dt>
     <dd><%= l @event.created_at %></dd>
   </dl>


### PR DESCRIPTION
This solves a display bug on events#show (UI problem) regarding to sent at

Production:
![screen shot 2015-09-15 at 15 51 46](https://cloud.githubusercontent.com/assets/565707/9879992/b4805c92-5bc1-11e5-9a3f-6e7f7c918531.png)

Staging1:
![screen shot 2015-09-15 at 15 51 29](https://cloud.githubusercontent.com/assets/565707/9880001/bc25a01a-5bc1-11e5-9a52-b6074e762f34.png)
